### PR TITLE
Allow to substitute the Contact entity

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -18,7 +18,7 @@ use JMS\Serializer\Annotation\VirtualProperty;
 use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface as CategoryEntity;
 use Sulu\Bundle\ContactBundle\Entity\BankAccount as BankAccountEntity;
-use Sulu\Bundle\ContactBundle\Entity\Contact as ContactEntity;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface as ContactEntity;
 use Sulu\Bundle\ContactBundle\Entity\ContactAddress as ContactAddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\ContactLocale as ContactLocaleEntity;
 use Sulu\Bundle\ContactBundle\Entity\Email as EmailEntity;


### PR DESCRIPTION
I tried to substitute the contact entity following this guide: https://docs.sulu.io/en/2.5/cookbook/extend-entities.html

Instead of extending the contact entity, I wanted my own implementation, as I don't want to ask the user about his first and last name because of GDPR issues, when using the SuluCommunityBundle. Extending the Contact-object leads to validating the first and last name, as all child objects automatically inherit the validation rules of the parent because of LSP.

When applying this PR, it would be possible, to completely substitute the Contact entity.

| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

<!-- Explain the contents of the PR. -->

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->

#### Example Usage

<!--
```php
// If you added new features, show examples of how to use them here

$foo = new Foo();

// Now we can do
$foo->doSomething();
```
-->

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
